### PR TITLE
Fix invalid character in href tag

### DIFF
--- a/src/_includes/social.njk
+++ b/src/_includes/social.njk
@@ -26,7 +26,7 @@
   </li>
   <li>
     Email:
-    <a href="mailto:meetup@joshghent.com?subject=LeicesterJS Meetup Question"
+    <a href="mailto:meetup@joshghent.com?subject=LeicesterJS%20Meetup%20Question"
       >meetup@joshghent.com</a>
   </li>
 </ul>


### PR DESCRIPTION
Removed spaces from href, picked up by linter as an invalid character.