### PR TITLE
Conditionally render rsvp section

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,6 +24,10 @@ module.exports = eleventyConfig => {
     return `${formattedStart} to ${formattedEnd}`;
   });
 
+  eleventyConfig.addPairedShortcode("isFuture", (content, startedAt) => {
+    return moment.utc(startedAt).isAfter(moment.utc()) ? content : "";
+  });
+
   // Plugins
   eleventyConfig.addPlugin(inclusiveLangPlugin);
 

--- a/src/_layouts/meetups.njk
+++ b/src/_layouts/meetups.njk
@@ -22,6 +22,8 @@ layout: layout.njk
 
 <a href="https://www.google.com/maps/search/?api=1&query={{ location | urlencode }}" target="_blank" rel="noopener noreferrer">{{ location }}</a>
 
-<h2>RSVP</h2>
+{% isFuture started_at %}
+  <h2>RSVP</h2>
 
-<a href="https://www.meetup.com/leicesterjs/events/{{ meetup_id }}/">RSVP here!</a>
+  <a href="https://www.meetup.com/leicesterjs/events/{{ meetup_id }}/">RSVP here!</a>
+{% endisFuture %}


### PR DESCRIPTION
Conditionally render rsvp section based on whether the event has already happened.

A note to reduce the string manipulation in order to create a new date would be to switch over to using a valid JS date format instead 🙂

This PR is for https://github.com/leicesterjs/site/issues/35