### PR TITLE
Feature #25 remove bonus tags

### DIFF
--- a/src/_layouts/layout.njk
+++ b/src/_layouts/layout.njk
@@ -3,14 +3,12 @@ title: LeicesterJS
 ---
 <!doctype html>
 <html lang="en">
-  <head>
     <meta charset="UTF-8" />
     <title>{{ title }}</title>
     <meta name="description" content="LeicesterJS is a meetup all about JavaScript. Come and discuss all things JavaScript, Node and software development!">
     <meta name="theme-color" content="#2e353f" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="/css/styles.css" />
-  </head>
 
   <body>
     <div class="container">
@@ -20,5 +18,4 @@ title: LeicesterJS
 
       {{ content | safe }}
     </div>
-  </body>
-</html>
+


### PR DESCRIPTION
Removed the closing html, head and body tags. Also removed the opening head tag. Left the html tag as it had an attribute also left the body tag as this is used as an anchor for the injected browser-sync script in development. 