### PR TITLE
Update leicesterjs slack invite link

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,6 +6,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addPassthroughCopy("src/img");
   eleventyConfig.addPassthroughCopy("src/js");
   eleventyConfig.addPassthroughCopy("src/favicon.ico");
+  eleventyConfig.addPassthroughCopy("src/_redirects");
 
   // Plugins
   eleventyConfig.addPlugin(inclusiveLangPlugin);

--- a/src/_includes/social.njk
+++ b/src/_includes/social.njk
@@ -15,8 +15,8 @@
   </li>
   <li>
     Slack:
-    <a href="https://bit.ly/leicesterjs-slack"
-      >https://bit.ly/leicesterjs-slack</a
+    <a href="/slack"
+      >https://www.leicesterjs.org/slack</a
     >
   </li>
   <li>

--- a/src/_redirects
+++ b/src/_redirects
@@ -1,0 +1,1 @@
+/slack https://join.slack.com/t/leicesterjs/shared_invite/enQtNDMwODk0ODQ4NTE2LWUyZWI3NGZlZmY1YTdlNWZjNDY1ZDZhZWJlNjNjOTg1ODUzOWRmMDZlMWM2NjlkZjIzNWZjZDAxODc4N2U1MzE


### PR DESCRIPTION
Setup a redirect link for the leicesterjs slack invite, allowing this to be swapped out easily in future when it expires