### PR TITLE
Fix logo jank in modern browsers

### DIFF
--- a/src/_layouts/layout.njk
+++ b/src/_layouts/layout.njk
@@ -28,7 +28,7 @@ title: LeicesterJS
 
   <body>
     <div class="container">
-      <a href="/"><img alt="Leicester JS" class="logo" src="/img/logo@2x.jpg" width="420" /></a>
+      <a href="/"><img alt="Leicester JS" class="logo" src="/img/logo@2x.jpg" width="1099" height="400" /></a>
 
       {% include "navigation.njk" %}
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -43,7 +43,9 @@ h2 {
 .logo {
   display: block;
   margin: 0 auto 2rem;
+  height: auto;
   max-width: 100%;
+  width: 80%;
 }
 
 .contributors {


### PR DESCRIPTION
If you add image width/height to your html and style width/height correctly then modern browsers will calculate the images aspect ratio and render it with no jankiness.

Jen Simmons explains best https://www.youtube.com/watch?v=4-d_SoCHeWE